### PR TITLE
Action buttons

### DIFF
--- a/src/edit/config.rs
+++ b/src/edit/config.rs
@@ -74,7 +74,8 @@ pub struct Config {
 
     pub cancel_key: ModifiedKey,
 
-    pub rotate_block_key: ModifiedKey,
+    pub rotate_block_cw_key: ModifiedKey,
+    pub rotate_block_ccw_key: ModifiedKey,
     pub block_kind_key: ModifiedKey,
 
     pub undo_key: ModifiedKey,
@@ -99,7 +100,8 @@ impl Default for Config {
         Config {
             default_save_path: PathBuf::from("machine.json"),
             cancel_key: ModifiedKey::new(VirtualKeyCode::Escape),
-            rotate_block_key: ModifiedKey::new(VirtualKeyCode::R),
+            rotate_block_cw_key: ModifiedKey::new(VirtualKeyCode::R),
+            rotate_block_ccw_key: ModifiedKey::shift(VirtualKeyCode::R),
             block_kind_key: ModifiedKey::new(VirtualKeyCode::C),
             undo_key: ModifiedKey::ctrl(VirtualKeyCode::Z),
             redo_key: ModifiedKey::ctrl(VirtualKeyCode::Y),

--- a/src/edit/editor.rs
+++ b/src/edit/editor.rs
@@ -8,7 +8,7 @@ use log::{info, warn};
 use nalgebra as na;
 
 use glium::glutin::{self, MouseButton, WindowEvent};
-use imgui::im_str;
+use imgui::{im_str, ImString};
 
 use crate::exec::{self, ExecView};
 use crate::input_state::InputState;
@@ -211,13 +211,13 @@ impl Editor {
             .bg_alpha(bg_alpha)
             .build(&ui, || {
                 for (block_key, block) in self.config.block_keys.clone().iter() {
-                    if ui.button(&imgui::ImString::new(block.name()), [button_w, button_h]) {
+                    if ui.button(&ImString::new(block.name()), [button_w, button_h]) {
                         self.switch_to_place_block_mode(*block);
                     }
 
                     if ui.is_item_hovered() {
                         let text = format!("{}\n\nShortcut: {}", block.description(), block_key);
-                        ui.tooltip(|| ui.text(&imgui::ImString::new(text)));
+                        ui.tooltip(|| ui.text(&ImString::new(text)));
                     }
                 }
             });
@@ -234,7 +234,7 @@ impl Editor {
                 }
                 if ui.is_item_hovered() {
                     let text = format!("Shortcut: {}", self.config.select_key);
-                    ui.tooltip(|| ui.text(&imgui::ImString::new(text)));
+                    ui.tooltip(|| ui.text(&ImString::new(text)));
                 }
 
                 ui.separator();
@@ -244,7 +244,7 @@ impl Editor {
                 }
                 if ui.is_item_hovered() {
                     let text = format!("Shortcut: {}", self.config.undo_key);
-                    ui.tooltip(|| ui.text(&imgui::ImString::new(text)));
+                    ui.tooltip(|| ui.text(&ImString::new(text)));
                 }
 
                 ui.same_line(0.0);
@@ -254,7 +254,7 @@ impl Editor {
                 }
                 if ui.is_item_hovered() {
                     let text = format!("Shortcut: {}", self.config.redo_key);
-                    ui.tooltip(|| ui.text(&imgui::ImString::new(text)));
+                    ui.tooltip(|| ui.text(&ImString::new(text)));
                 }
             });
     }

--- a/src/edit/editor.rs
+++ b/src/edit/editor.rs
@@ -210,8 +210,19 @@ impl Editor {
             .position_pivot([1.0, 0.0])
             .bg_alpha(bg_alpha)
             .build(&ui, || {
+                let cur_block = match &self.mode {
+                    Mode::PlacePiece(piece) => piece.get_singleton(),
+                    _ => None,
+                };
+
                 for (block_key, block) in self.config.block_keys.clone().iter() {
-                    if ui.button(&ImString::new(block.name()), [button_w, button_h]) {
+                    let name = &ImString::new(block.name());
+                    let selected = cur_block
+                        .as_ref()
+                        .map_or(false, |placed_block| placed_block.block == *block);
+                    let selectable = imgui::Selectable::new(name).selected(selected);
+
+                    if selectable.build(ui) {
                         self.switch_to_place_block_mode(*block);
                     }
 

--- a/src/edit/editor.rs
+++ b/src/edit/editor.rs
@@ -252,7 +252,6 @@ impl Editor {
                 }
 
                 ui.separator();
-                ui.separator();
 
                 if ui.button(im_str!("Undo"), [small_button_w, button_h]) {
                     self.action_undo();
@@ -275,7 +274,6 @@ impl Editor {
                     ui.tooltip(|| ui.text(&ImString::new(text)));
                 }
 
-                ui.separator();
                 ui.separator();
 
                 if ui.button(im_str!("Paste"), [button_w, button_h]) {
@@ -313,7 +311,6 @@ impl Editor {
                     ui.tooltip(|| ui.text(&ImString::new(text)));
                 }
 
-                ui.separator();
                 ui.separator();
 
                 ui.set_window_font_scale(1.5);
@@ -839,25 +836,43 @@ impl Editor {
     }
 
     pub fn action_rotate_cw(&mut self) {
+        let mut edit = None;
+
         match &mut self.mode {
             Mode::PlacePiece(piece) => {
                 piece.rotate_cw_xy();
             }
+            Mode::Select(selection) => {
+                edit = Some(Edit::RotateCWXY(selection.clone()));
+            }
             _ => {
                 // No op in other modes.
             }
         };
+
+        if let Some(edit) = edit {
+            self.run_and_track_edit(edit);
+        }
     }
 
     pub fn action_rotate_ccw(&mut self) {
+        let mut edit = None;
+
         match &mut self.mode {
             Mode::PlacePiece(piece) => {
                 piece.rotate_ccw_xy();
             }
+            Mode::Select(selection) => {
+                edit = Some(Edit::RotateCCWXY(selection.clone()));
+            }
             _ => {
                 // No op in other modes.
             }
         };
+
+        if let Some(edit) = edit {
+            self.run_and_track_edit(edit);
+        }
     }
 
     pub fn action_next_kind(&mut self) {

--- a/src/edit/editor.rs
+++ b/src/edit/editor.rs
@@ -198,7 +198,7 @@ impl Editor {
 
     pub fn ui(&mut self, ui: &imgui::Ui) {
         let button_w = 140.0;
-        let button_h = 40.0;
+        let button_h = 25.0;
         let small_button_w = 66.25;
         let bg_alpha = 0.8;
 
@@ -238,6 +238,7 @@ impl Editor {
                 }
 
                 ui.separator();
+                ui.separator();
 
                 if ui.button(im_str!("Undo"), [small_button_w, button_h]) {
                     self.action_undo();
@@ -254,6 +255,54 @@ impl Editor {
                 }
                 if ui.is_item_hovered() {
                     let text = format!("Shortcut: {}", self.config.redo_key);
+                    ui.tooltip(|| ui.text(&ImString::new(text)));
+                }
+
+                ui.separator();
+
+                if ui.button(im_str!("Paste"), [button_w, button_h]) {
+                    self.action_paste();
+                }
+                if ui.is_item_hovered() {
+                    let text = format!("Shortcut: {}", self.config.paste_key);
+                    ui.tooltip(|| ui.text(&ImString::new(text)));
+                }
+
+                if ui.button(im_str!("Copy"), [small_button_w, button_h]) {
+                    self.action_copy();
+                }
+                if ui.is_item_hovered() {
+                    let text = format!("Shortcut: {}", self.config.copy_key);
+                    ui.tooltip(|| ui.text(&ImString::new(text)));
+                }
+
+                ui.same_line(0.0);
+
+                if ui.button(im_str!("Cut"), [small_button_w, button_h]) {
+                    self.action_cut();
+                }
+                if ui.is_item_hovered() {
+                    let text = format!("Shortcut: {}", self.config.cut_key);
+                    ui.tooltip(|| ui.text(&ImString::new(text)));
+                }
+
+                ui.separator();
+
+                if ui.button(im_str!("↻"), [small_button_w, button_h]) {
+                    self.action_rotate_cw();
+                }
+                if ui.is_item_hovered() {
+                    let text = format!("Shortcut: {}", self.config.rotate_block_cw_key);
+                    ui.tooltip(|| ui.text(&ImString::new(text)));
+                }
+
+                ui.same_line(0.0);
+
+                if ui.button(im_str!("↺"), [small_button_w, button_h]) {
+                    self.action_rotate_ccw();
+                }
+                if ui.is_item_hovered() {
+                    let text = format!("Shortcut: {}", self.config.rotate_block_ccw_key);
                     ui.tooltip(|| ui.text(&ImString::new(text)));
                 }
             });
@@ -372,12 +421,10 @@ impl Editor {
             self.action_copy();
         } else if key == self.config.block_kind_key {
             self.action_next_kind();
-        } else if key.key == self.config.rotate_block_key.key {
-            if !key.shift {
-                self.action_rotate_cw();
-            } else {
-                self.action_rotate_ccw();
-            }
+        } else if key == self.config.rotate_block_cw_key {
+            self.action_rotate_cw();
+        } else if key == self.config.rotate_block_ccw_key {
+            self.action_rotate_ccw();
         }
 
         // Switch to specific layer

--- a/src/edit/editor.rs
+++ b/src/edit/editor.rs
@@ -666,12 +666,14 @@ impl Editor {
     pub fn action_cut(&mut self) {
         let edit = match &self.mode {
             Mode::Select(selection) => {
-                let mut selected_blocks = HashMap::new();
-                for p in selection.iter() {
-                    if let Some((_, placed_block)) = self.machine.get_block_at_pos(p) {
-                        selected_blocks.insert(*p, placed_block.clone());
-                    }
-                }
+                let mut selected_blocks = selection
+                    .iter()
+                    .filter_map(|p| {
+                        self.machine
+                            .get_block_at_pos(p)
+                            .map(|(_, b)| (*p, b.clone()))
+                    })
+                    .collect();
                 self.clipboard = Some(Piece::new_blocks_to_origin(selected_blocks));
 
                 // Note that `run_and_track_edit` will automatically clear the
@@ -694,12 +696,14 @@ impl Editor {
     pub fn action_copy(&mut self) {
         match &self.mode {
             Mode::Select(selection) => {
-                let mut selected_blocks = HashMap::new();
-                for p in selection.iter() {
-                    if let Some((_, placed_block)) = self.machine.get_block_at_pos(p) {
-                        selected_blocks.insert(*p, placed_block.clone());
-                    }
-                }
+                let mut selected_blocks = selection
+                    .iter()
+                    .filter_map(|p| {
+                        self.machine
+                            .get_block_at_pos(p)
+                            .map(|(_, b)| (*p, b.clone()))
+                    })
+                    .collect();
                 self.clipboard = Some(Piece::new_blocks_to_origin(selected_blocks));
             }
             _ => {

--- a/src/edit/editor.rs
+++ b/src/edit/editor.rs
@@ -233,7 +233,10 @@ impl Editor {
                     self.mode = Mode::Select(Vec::new());
                 }
                 if ui.is_item_hovered() {
-                    let text = format!("Shortcut: {}", self.config.select_key);
+                    let text = format!(
+                        "Switch to block selection mode.\n\nShortcut: {}",
+                        self.config.select_key
+                    );
                     ui.tooltip(|| ui.text(&ImString::new(text)));
                 }
 
@@ -244,7 +247,7 @@ impl Editor {
                     self.action_undo();
                 }
                 if ui.is_item_hovered() {
-                    let text = format!("Shortcut: {}", self.config.undo_key);
+                    let text = format!("Undo the last edit.\n\nShortcut: {}", self.config.undo_key);
                     ui.tooltip(|| ui.text(&ImString::new(text)));
                 }
 
@@ -254,7 +257,10 @@ impl Editor {
                     self.action_redo();
                 }
                 if ui.is_item_hovered() {
-                    let text = format!("Shortcut: {}", self.config.redo_key);
+                    let text = format!(
+                        "Take back the last undo.\n\nShortcut: {}",
+                        self.config.redo_key
+                    );
                     ui.tooltip(|| ui.text(&ImString::new(text)));
                 }
 
@@ -264,7 +270,10 @@ impl Editor {
                     self.action_paste();
                 }
                 if ui.is_item_hovered() {
-                    let text = format!("Shortcut: {}", self.config.paste_key);
+                    let text = format!(
+                        "Start placing the last copied blocks.\n\nShortcut: {}",
+                        self.config.paste_key
+                    );
                     ui.tooltip(|| ui.text(&ImString::new(text)));
                 }
 
@@ -272,7 +281,10 @@ impl Editor {
                     self.action_copy();
                 }
                 if ui.is_item_hovered() {
-                    let text = format!("Shortcut: {}", self.config.copy_key);
+                    let text = format!(
+                        "Copy selected blocks.\n\nShortcut: {}",
+                        self.config.copy_key
+                    );
                     ui.tooltip(|| ui.text(&ImString::new(text)));
                 }
 
@@ -282,7 +294,10 @@ impl Editor {
                     self.action_cut();
                 }
                 if ui.is_item_hovered() {
-                    let text = format!("Shortcut: {}", self.config.cut_key);
+                    let text = format!(
+                        "Copy and remove selected blocks.\n\nShortcut: {}",
+                        self.config.cut_key
+                    );
                     ui.tooltip(|| ui.text(&ImString::new(text)));
                 }
 
@@ -292,7 +307,10 @@ impl Editor {
                     self.action_rotate_cw();
                 }
                 if ui.is_item_hovered() {
-                    let text = format!("Shortcut: {}", self.config.rotate_block_cw_key);
+                    let text = format!(
+                        "Rotate blocks to be placed clockwise.\n\nShortcut: {}",
+                        self.config.rotate_block_cw_key
+                    );
                     ui.tooltip(|| ui.text(&ImString::new(text)));
                 }
 
@@ -302,7 +320,10 @@ impl Editor {
                     self.action_rotate_ccw();
                 }
                 if ui.is_item_hovered() {
-                    let text = format!("Shortcut: {}", self.config.rotate_block_ccw_key);
+                    let text = format!(
+                        "Rotate blocks to be placed counterclockwise.\n\nShortcut: {}",
+                        self.config.rotate_block_ccw_key
+                    );
                     ui.tooltip(|| ui.text(&ImString::new(text)));
                 }
             });

--- a/src/edit/editor.rs
+++ b/src/edit/editor.rs
@@ -265,6 +265,7 @@ impl Editor {
                 }
 
                 ui.separator();
+                ui.separator();
 
                 if ui.button(im_str!("Paste"), [button_w, button_h]) {
                     self.action_paste();
@@ -302,7 +303,9 @@ impl Editor {
                 }
 
                 ui.separator();
+                ui.separator();
 
+                ui.set_window_font_scale(1.5);
                 if ui.button(im_str!("↻"), [small_button_w, button_h]) {
                     self.action_rotate_cw();
                 }
@@ -326,6 +329,7 @@ impl Editor {
                     );
                     ui.tooltip(|| ui.text(&ImString::new(text)));
                 }
+                ui.set_window_font_scale(1.0);
             });
     }
 
@@ -751,7 +755,7 @@ impl Editor {
     pub fn action_cut(&mut self) {
         let edit = match &self.mode {
             Mode::Select(selection) => {
-                let mut selected_blocks = selection
+                let selected_blocks = selection
                     .iter()
                     .filter_map(|p| {
                         self.machine
@@ -781,7 +785,7 @@ impl Editor {
     pub fn action_copy(&mut self) {
         match &self.mode {
             Mode::Select(selection) => {
-                let mut selected_blocks = selection
+                let selected_blocks = selection
                     .iter()
                     .filter_map(|p| {
                         self.machine

--- a/src/edit/mod.rs
+++ b/src/edit/mod.rs
@@ -103,6 +103,18 @@ impl Piece {
             .map(move |(pos, block)| (pos + offset, block.clone()))
     }
 
+    pub fn get_singleton(&self) -> Option<PlacedBlock> {
+        if let Some(block) = self.blocks.values().next() {
+            if self.blocks.len() == 1 {
+                Some(block.clone())
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    }
+
     pub fn blocks_to_origin(
         blocks: HashMap<grid::Point3, PlacedBlock>,
     ) -> HashMap<grid::Point3, PlacedBlock> {

--- a/src/edit/mod.rs
+++ b/src/edit/mod.rs
@@ -143,6 +143,12 @@ impl Piece {
 pub enum Edit {
     NoOp,
     SetBlocks(HashMap<grid::Point3, Option<PlacedBlock>>),
+
+    /// Rotate blocks clockwise.
+    RotateCWXY(Vec<grid::Point3>),
+
+    /// Rotate blocks counterclockwise.
+    RotateCCWXY(Vec<grid::Point3>),
 }
 
 impl Edit {
@@ -177,6 +183,32 @@ impl Edit {
                     }
 
                     Edit::SetBlocks(previous_blocks)
+                }
+            }
+            Edit::RotateCWXY(points) => {
+                for p in &points {
+                    if let Some((_, placed_block)) = machine.get_block_at_pos_mut(p) {
+                        placed_block.rotate_cw_xy();
+                    }
+                }
+
+                if points.is_empty() {
+                    Edit::NoOp
+                } else {
+                    Edit::RotateCCWXY(points)
+                }
+            }
+            Edit::RotateCCWXY(points) => {
+                for p in &points {
+                    if let Some((_, placed_block)) = machine.get_block_at_pos_mut(p) {
+                        placed_block.rotate_ccw_xy();
+                    }
+                }
+
+                if points.is_empty() {
+                    Edit::NoOp
+                } else {
+                    Edit::RotateCWXY(points)
                 }
             }
         }

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -363,8 +363,16 @@ impl Machine {
         self.blocks
             .indices
             .get(p)
-            .and_then(|id| id.as_ref())
-            .map(|&id| (id, &self.blocks.data[id].1))
+            .and_then(|id| *id)
+            .map(|id| (id, &self.blocks.data[id].1))
+    }
+
+    pub fn get_block_at_pos_mut(&mut self, p: &Point3) -> Option<(BlockIndex, &mut PlacedBlock)> {
+        self.blocks
+            .indices
+            .get(p)
+            .and_then(|id| *id)
+            .map(move |id| (id, &mut self.blocks.data[id].1))
     }
 
     pub fn block_at_index(&self, index: BlockIndex) -> &(Point3, PlacedBlock) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,7 @@ fn main() {
         let glyph_ranges = imgui::FontGlyphRanges::from_slice(&[
             0x0020, 0x00FF, // Basic Latin + Latin Supplement
             0x25A0, 0x25FF, // Geometric shapes
+            0x2190, 0x21FF, // Arrows
             0,
         ]);
 
@@ -185,8 +186,6 @@ fn main() {
             info!("Window resized to: {:?}", new_window_size);
 
             game.on_window_resize(&display, new_window_size);
-
-            //font.on_window_resize(new_window_size);
         }
 
         let now_clock = Instant::now();

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,10 +71,18 @@ fn main() {
         let hidpi_factor = imgui_platform.hidpi_factor();
         let font_size = (14.0 * hidpi_factor) as f32;
 
+        // Include some special characters in the glyph ranges
+        let glyph_ranges = imgui::FontGlyphRanges::from_slice(&[
+            0x0020, 0x00FF, // Basic Latin + Latin Supplement
+            0x25A0, 0x25FF, // Geometric shapes
+            0,
+        ]);
+
         imgui.fonts().add_font(&[imgui::FontSource::TtfData {
             data: include_bytes!("../resources/DejaVuSans.ttf"),
             size_pixels: font_size,
             config: Some(imgui::FontConfig {
+                glyph_ranges,
                 ..imgui::FontConfig::default()
             }),
         }]);


### PR DESCRIPTION
Work on the editor:
- Use selectables instead of buttons for blocks
- Rotate selected buttons
- Refactor editor actions into more clean methods
- Add some buttons for undo/redo/rotate etc.