### PR TITLE
Colors again

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,8 @@
 # TODO
+## Movement
+- Turn faster on shift
+- Shame pulsator for crossing
+
 ## Editor
 - Select all
 - Not allowing deletion of `Block::Input` and `Block::Output`

--- a/TODO.md
+++ b/TODO.md
@@ -13,9 +13,7 @@
 ## Rendering
 - Render block inputs
 
-- Fix rough edges of deferred shading
 - Check if it's okay to rely on `glutin::dpi::LogicalSize` for texture sizes
-- Make generic over glium `Display` where it is not yet
 - Instanced rendering to reduce draw calls
 
 ## Gameplay

--- a/src/edit/editor/render.rs
+++ b/src/edit/editor/render.rs
@@ -7,6 +7,9 @@ use crate::machine::{Block, PlacedBlock};
 use crate::render;
 use crate::render::pipeline::RenderLists;
 
+pub const GRID_OFFSET_Z: f32 = 0.01;
+pub const GRID_OFFSET_2_Z: f32 = 0.02;
+
 impl Editor {
     pub fn render(&mut self, out: &mut RenderLists) -> Result<(), glium::DrawError> {
         profile!("editor");
@@ -14,7 +17,7 @@ impl Editor {
         let grid_size: na::Vector3<f32> = na::convert(self.machine.size());
         render::machine::render_cuboid_wireframe(
             &render::machine::Cuboid {
-                center: na::Point3::from(grid_size / 2.0),
+                center: na::Point3::from(grid_size / 2.0) + na::Vector3::z() * GRID_OFFSET_2_Z,
                 size: grid_size,
             },
             0.1,
@@ -37,7 +40,7 @@ impl Editor {
 
         render::machine::render_xy_grid(
             &self.machine.size(),
-            self.current_layer as f32 + 0.01,
+            self.current_layer as f32 + GRID_OFFSET_Z,
             &mut out.plain,
         );
 
@@ -183,7 +186,7 @@ impl Editor {
 
             render::machine::render_cuboid_wireframe(
                 &render::machine::Cuboid {
-                    center: grid_pos_float + na::Vector3::new(0.5, 0.5, 0.51),
+                    center: grid_pos_float + na::Vector3::new(0.5, 0.5, 0.5 + GRID_OFFSET_2_Z),
                     size: na::Vector3::new(1.0, 1.0, 1.0),
                 },
                 0.025,
@@ -205,7 +208,7 @@ impl Editor {
         render::machine::render_cuboid_wireframe(
             &render::machine::Cuboid {
                 // Slight z offset so that there is less overlap with e.g. the floor
-                center: pos + na::Vector3::new(0.5, 0.5, 0.51),
+                center: pos + na::Vector3::new(0.5, 0.5, 0.5 + GRID_OFFSET_2_Z),
                 size: na::Vector3::new(1.0, 1.0, 1.0),
             },
             thickness,
@@ -282,7 +285,7 @@ impl Editor {
             let wire_center = piece_pos + wire_size / 2.0;
             render::machine::render_cuboid_wireframe(
                 &render::machine::Cuboid {
-                    center: wire_center,
+                    center: wire_center + na::Vector3::z() * GRID_OFFSET_2_Z,
                     size: wire_size,
                 },
                 0.015,

--- a/src/exec/play.rs
+++ b/src/exec/play.rs
@@ -1,5 +1,5 @@
-use std::time::Duration;
 use std::fmt;
+use std::time::Duration;
 
 use glium::glutin::{ElementState, VirtualKeyCode, WindowEvent};
 use imgui::{im_str, ImString};

--- a/src/exec/play.rs
+++ b/src/exec/play.rs
@@ -1,4 +1,5 @@
 use std::time::Duration;
+use std::fmt;
 
 use glium::glutin::{ElementState, VirtualKeyCode, WindowEvent};
 use imgui::{im_str, ImString};
@@ -58,6 +59,12 @@ impl TickTime {
 
     pub fn tick_progress(&self) -> f32 {
         self.next_tick_timer.progress()
+    }
+}
+
+impl fmt::Display for TickTime {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:.2}", self.as_f32())
     }
 }
 
@@ -157,7 +164,7 @@ impl Play {
 
         match &status {
             Some(Status::Playing { time, .. }) if play_pause_pressed => {
-                info!("Pausing exec");
+                info!("Pausing exec at time {}", time);
                 Some(Status::Paused { time: time.clone() })
             }
             Some(Status::Playing { .. }) if stop_pressed => None,
@@ -179,18 +186,18 @@ impl Play {
                 })
             }
             Some(Status::Paused { time }) if play_pause_pressed => {
-                info!("Resuming exec");
+                info!("Resuming exec at time {}", time);
                 Some(Status::Playing {
                     num_ticks_since_last_update: 0,
                     time: time.clone(),
                 })
             }
-            Some(Status::Paused { .. }) if stop_pressed => {
-                info!("Stopping exec");
+            Some(Status::Paused { time }) if stop_pressed => {
+                info!("Stopping exec at time {}", time);
                 None
             }
-            Some(Status::Finished { .. }) if stop_pressed => {
-                info!("Stopping exec");
+            Some(Status::Finished { time }) if stop_pressed => {
+                info!("Stopping exec at time {}", time);
                 None
             }
             Some(Status::Finished { time }) => {

--- a/src/exec/view.rs
+++ b/src/exec/view.rs
@@ -312,7 +312,7 @@ impl ExecView {
             };
 
             let mut transform =
-                na::Matrix4::new_translation(&pos.coords) * na::Matrix4::new_scaling(size);
+                na::Matrix4::new_translation(&pos.coords) ;
 
             // Rotate blip if it is moving
             if let Some(old_move_dir) = blip.old_move_dir {
@@ -328,10 +328,12 @@ impl ExecView {
                 object: render::Object::Cube,
                 params: render::pipeline::DefaultInstanceParams {
                     color: na::Vector4::new(color.x, color.y, color.z, 1.0),
-                    transform,
+                    transform: transform * na::Matrix4::new_scaling(size),
                     ..Default::default()
                 },
             };
+
+            render::machine::render_outline(&transform, &na::Vector3::new(size, size, size), 0.0, out);
 
             out.solid_glow.add_instance(&instance);
             //out.solid.add_instance(&instance);

--- a/src/exec/view.rs
+++ b/src/exec/view.rs
@@ -330,7 +330,7 @@ impl ExecView {
 
             out.lights.push(render::pipeline::Light {
                 position: pos,
-                attenuation: na::Vector3::new(1.0, 0.0, 2.0),
+                attenuation: na::Vector3::new(1.0, 0.0, 0.2),
                 color: render::machine::blip_color(blip.kind),
                 radius: 2.0,
             });

--- a/src/exec/view.rs
+++ b/src/exec/view.rs
@@ -334,7 +334,7 @@ impl ExecView {
 
             out.lights.push(render::pipeline::Light {
                 position: pos,
-                attenuation: na::Vector3::new(1.0, 0.0, 2.0),
+                attenuation: na::Vector3::new(1.0, 0.0, 6.0),
                 color: 20.0 * render::machine::blip_color(blip.kind),
                 is_main: false,
             });

--- a/src/exec/view.rs
+++ b/src/exec/view.rs
@@ -332,7 +332,7 @@ impl ExecView {
                 position: pos,
                 attenuation: na::Vector3::new(1.0, 0.0, 2.0),
                 color: 20.0 * render::machine::blip_color(blip.kind),
-                radius: 2.0,
+                is_main: false,
             });
         }
     }

--- a/src/exec/view.rs
+++ b/src/exec/view.rs
@@ -285,7 +285,11 @@ impl ExecView {
                 * match blip.status {
                     BlipStatus::Spawning => {
                         // Animate spawning the blip
-                        Self::blip_spawn_size_animation(time.tick_progress())
+                        if time.tick_progress() >= 0.75 {
+                            Self::blip_spawn_size_animation((time.tick_progress() - 0.75) * 4.0)
+                        } else {
+                            0.0
+                        }
                     }
                     BlipStatus::Existing => 1.0,
                     BlipStatus::Dying => {

--- a/src/exec/view.rs
+++ b/src/exec/view.rs
@@ -330,8 +330,8 @@ impl ExecView {
 
             out.lights.push(render::pipeline::Light {
                 position: pos,
-                attenuation: na::Vector3::new(1.0, 0.0, 0.2),
-                color: render::machine::blip_color(blip.kind),
+                attenuation: na::Vector3::new(1.0, 0.0, 2.0),
+                color: 20.0 * render::machine::blip_color(blip.kind),
                 radius: 2.0,
             });
         }

--- a/src/exec/view.rs
+++ b/src/exec/view.rs
@@ -180,12 +180,16 @@ impl ExecView {
         let color = render::machine::wind_source_color();
         let color = na::Vector4::new(color.x, color.y, color.z, 1.0);
 
+        let stripe_color = render::machine::wind_stripe_color();
+        let stripe_color = na::Vector4::new(stripe_color.x, stripe_color.y, stripe_color.z, 1.0);
+
         for &phase in &[0.0, 0.25, 0.5, 0.75] {
             out.wind.add(
                 render::Object::TessellatedCylinder,
                 &wind::Params {
                     transform,
                     color,
+                    stripe_color,
                     start: in_t,
                     end: out_t,
                     phase: 2.0 * phase * std::f32::consts::PI,

--- a/src/exec/view.rs
+++ b/src/exec/view.rs
@@ -318,7 +318,7 @@ impl ExecView {
             if let Some(old_move_dir) = blip.old_move_dir {
                 let old_pos = blip.pos - old_move_dir.to_vector();
                 let delta: na::Vector3<f32> = na::convert(blip.pos - old_pos);
-                let angle = time.tick_progress() * std::f32::consts::PI / 2.0;
+                let angle = -time.tick_progress() * std::f32::consts::PI / 2.0;
                 let rot = na::Rotation3::new(delta.normalize() * angle);
                 transform = transform * rot.to_homogeneous();
             }

--- a/src/exec/view.rs
+++ b/src/exec/view.rs
@@ -311,8 +311,7 @@ impl ExecView {
                 center
             };
 
-            let mut transform =
-                na::Matrix4::new_translation(&pos.coords) ;
+            let mut transform = na::Matrix4::new_translation(&pos.coords);
 
             // Rotate blip if it is moving
             if let Some(old_move_dir) = blip.old_move_dir {
@@ -333,7 +332,12 @@ impl ExecView {
                 },
             };
 
-            render::machine::render_outline(&transform, &na::Vector3::new(size, size, size), 0.0, out);
+            render::machine::render_outline(
+                &transform,
+                &na::Vector3::new(size, size, size),
+                0.0,
+                out,
+            );
 
             out.solid_glow.add_instance(&instance);
             //out.solid.add_instance(&instance);

--- a/src/game.rs
+++ b/src/game.rs
@@ -154,7 +154,7 @@ impl Game {
             position: render_context.main_light_pos,
             attenuation: na::Vector3::new(1.0, 0.0, 0.0),
             color: na::Vector3::new(1.0, 1.0, 1.0),
-            radius: 160.0,
+            is_main: true,
         });
 
         self.render_pipeline.draw_frame(

--- a/src/game.rs
+++ b/src/game.rs
@@ -150,6 +150,13 @@ impl Game {
             main_light_center: na::Point3::new(15.0, 15.0, 0.0),
         };
 
+        self.render_lists.lights.push(render::pipeline::Light {
+            position: render_context.main_light_pos,
+            attenuation: na::Vector3::new(1.0, 0.0, 0.0),
+            color: na::Vector3::new(1.0, 1.0, 1.0),
+            radius: 160.0,
+        });
+
         self.render_pipeline.draw_frame(
             display,
             &self.resources,

--- a/src/render/machine.rs
+++ b/src/render/machine.rs
@@ -25,6 +25,10 @@ pub fn wind_source_color() -> na::Vector3<f32> {
     gamma_correct(&na::Vector3::new(1.0, 0.557, 0.0))
 }
 
+pub fn wind_stripe_color() -> na::Vector3<f32> {
+    gamma_correct(&na::Vector3::new(1.0, 0.325, 0.286))
+}
+
 pub fn blip_spawn_color() -> na::Vector3<f32> {
     gamma_correct(&(na::Vector3::new(60.0, 179.0, 113.0) / 255.0))
 }

--- a/src/render/machine.rs
+++ b/src/render/machine.rs
@@ -85,8 +85,8 @@ pub fn output_status_color(failed: bool, completed: bool) -> na::Vector3<f32> {
 }
 
 pub fn floor_color() -> na::Vector3<f32> {
-    gamma_correct(&na::Vector3::new(0.1608, 0.4235, 0.5725))
-    //na::Vector3::new(0.3, 0.3, 0.3)
+    //gamma_correct(&na::Vector3::new(0.1608, 0.4235, 0.5725))
+    gamma_correct(&na::Vector3::new(0.2, 0.2, 0.2))
 }
 
 #[derive(Clone, Debug)]

--- a/src/render/machine.rs
+++ b/src/render/machine.rs
@@ -105,7 +105,7 @@ pub fn render_line(line: &Line, out: &mut RenderList<DefaultInstanceParams>) {
 
     // This will roll the line somewhat, works nicely for the cuboid wireframe
     let up = d.cross(&na::Vector3::x()) + d.cross(&na::Vector3::y()) + d.cross(&na::Vector3::z());
-    let rot = na::Rotation3::new(d.normalize() * line.roll);
+    let rot = na::Rotation3::new(d.normalize() * (line.roll + std::f32::consts::PI / 4.0));
     let look_at = na::Isometry3::face_towards(&center, &line.end, &(rot * up));
 
     let scaling = na::Vector3::new(
@@ -772,26 +772,6 @@ pub fn render_block(
             );
         }
     }
-}
-
-pub fn render_arrow(line: &Line, _roll: f32, out: &mut RenderList<DefaultInstanceParams>) {
-    render_line(line, out);
-
-    // TODO
-    /*let head_transform = na::Matrix4::face_towards(
-        &line.end,
-        &(line.end + (line.end - line.start)),
-        &na::Vector3::y(),
-    ) * na::Matrix4::new_scaling(0.9);
-
-    out.add(
-        Object::Triangle,
-        &DefaultInstanceParams {
-            transform: head_transform,
-            color: line.color,
-            ..Default::default()
-        },
-    );*/
 }
 
 pub fn block_center(pos: &grid::Point3) -> na::Point3<f32> {

--- a/src/render/machine.rs
+++ b/src/render/machine.rs
@@ -3,7 +3,7 @@ use nalgebra as na;
 use crate::machine::grid::{self, Dir3};
 use crate::machine::{level, BlipKind, Block, Machine, PlacedBlock};
 
-use crate::render::pipeline::{DefaultInstanceParams, RenderList, RenderLists};
+use crate::render::pipeline::{DefaultInstanceParams, Light, RenderList, RenderLists};
 use crate::render::Object;
 
 use crate::exec::anim::{WindAnimState, WindLife};
@@ -490,6 +490,15 @@ pub fn render_block(
                 },
             );
 
+            if wind_anim_state.is_some() {
+                out.lights.push(Light {
+                    position: *center,
+                    attenuation: na::Vector3::new(1.0, 0.0, 3.0),
+                    color: 8.0 * wind_source_color(),
+                    is_main: false,
+                });
+            }
+
             render_wind_mills(
                 placed_block,
                 tick_time,
@@ -615,6 +624,15 @@ pub fn render_block(
                     ..Default::default()
                 },
             );
+
+            if activated {
+                out.lights.push(Light {
+                    position: *center,
+                    attenuation: na::Vector3::new(1.0, 0.0, 3.0),
+                    color: 8.0 * wind_source_color(),
+                    is_main: false,
+                });
+            }
 
             let button_length = if activated { 0.4 } else { 0.45 };
             render_bridge(

--- a/src/render/machine.rs
+++ b/src/render/machine.rs
@@ -13,7 +13,7 @@ pub const PIPE_THICKNESS: f32 = 0.05;
 pub const MILL_THICKNESS: f32 = 0.2;
 pub const MILL_DEPTH: f32 = 0.09;
 pub const OUTLINE_THICKNESS: f32 = 0.02;
-pub const OUTLINE_MARGIN: f32 = 0.015;
+pub const OUTLINE_MARGIN: f32 = 0.005;
 
 const GAMMA: f32 = 2.2;
 
@@ -98,7 +98,7 @@ pub fn floor_color() -> na::Vector3<f32> {
 }
 
 pub fn outline_color() -> na::Vector3<f32> {
-    gamma_correct(&na::Vector3::new(0.05, 0.05, 0.05))
+    gamma_correct(&na::Vector3::new(0.01, 0.01, 0.01))
 }
 
 #[derive(Clone, Debug)]
@@ -122,21 +122,28 @@ pub fn render_line(
 
     let d = line_end - line_start;
 
-    // This will roll the line somewhat, works nicely for the cuboid wireframe
     let up = d.cross(&na::Vector3::x()) + d.cross(&na::Vector3::y()) + d.cross(&na::Vector3::z());
     let rot = na::Rotation3::new(d.normalize() * (line.roll + std::f32::consts::PI / 4.0));
     let look_at = na::Isometry3::face_towards(&center, &line_end, &(rot * up));
 
     let scaling = na::Vector3::new(
-        line.thickness,
-        line.thickness,
         (line_end - line_start).norm(),
+        line.thickness,
+        line.thickness,
     );
 
-    let cube_transform = look_at.to_homogeneous() * na::Matrix4::new_nonuniform_scaling(&scaling);
+    // TODO: Hack
+    let cube_transform = na::Matrix4::from_columns(&[
+        na::Vector4::new(d.x, d.y, d.z, 0.0),
+        na::Vector4::zeros(),
+        na::Vector4::zeros(),
+        na::Vector4::new(line_start.x, line_start.y, line_start.z, 1.0),
+    ]);
+
+    //let cube_transform = look_at.to_homogeneous() * na::Matrix4::new_nonuniform_scaling(&scaling);
 
     out.add(
-        Object::Cube,
+        Object::LineX,
         &DefaultInstanceParams {
             transform: cube_transform,
             color: line.color,

--- a/src/render/machine.rs
+++ b/src/render/machine.rs
@@ -38,7 +38,7 @@ pub fn blip_color(kind: BlipKind) -> na::Vector3<f32> {
 }
 
 pub fn pipe_color() -> na::Vector3<f32> {
-    gamma_correct(&na::Vector3::new(0.75, 0.75, 0.75))
+    gamma_correct(&na::Vector3::new(0.85, 0.85, 0.85))
 }
 
 pub fn funnel_in_color() -> na::Vector3<f32> {
@@ -50,7 +50,7 @@ pub fn funnel_out_color() -> na::Vector3<f32> {
 }
 
 pub fn inactive_blip_duplicator_color() -> na::Vector3<f32> {
-    gamma_correct(&na::Vector3::new(0.6, 0.6, 0.6))
+    gamma_correct(&na::Vector3::new(0.7, 0.7, 0.7))
 }
 
 pub fn inactive_blip_wind_source_color() -> na::Vector3<f32> {
@@ -67,11 +67,11 @@ pub fn wind_mill_color() -> na::Vector3<f32> {
 }
 
 pub fn patient_bridge_color() -> na::Vector3<f32> {
-    gamma_correct(&na::Vector3::new(0.9, 0.9, 0.9))
+    gamma_correct(&na::Vector3::new(0.95, 0.95, 0.95))
 }
 
 pub fn impatient_bridge_color() -> na::Vector3<f32> {
-    gamma_correct(&na::Vector3::new(0.8, 0.8, 0.8))
+    gamma_correct(&na::Vector3::new(0.9, 0.9, 0.9))
 }
 
 pub fn output_status_color(failed: bool, completed: bool) -> na::Vector3<f32> {
@@ -86,7 +86,7 @@ pub fn output_status_color(failed: bool, completed: bool) -> na::Vector3<f32> {
 
 pub fn floor_color() -> na::Vector3<f32> {
     //gamma_correct(&na::Vector3::new(0.1608, 0.4235, 0.5725))
-    gamma_correct(&na::Vector3::new(0.2, 0.2, 0.2))
+    gamma_correct(&na::Vector3::new(0.3, 0.3, 0.3))
 }
 
 #[derive(Clone, Debug)]

--- a/src/render/machine.rs
+++ b/src/render/machine.rs
@@ -301,7 +301,6 @@ pub fn render_wind_mills(
             }
 
             std::f32::consts::PI
-                * 2.0
                 * match anim.wind_out(dir) {
                     WindLife::None => 0.0,
                     WindLife::Appearing => {

--- a/src/render/machine.rs
+++ b/src/render/machine.rs
@@ -13,7 +13,7 @@ pub const PIPE_THICKNESS: f32 = 0.05;
 pub const MILL_THICKNESS: f32 = 0.2;
 pub const MILL_DEPTH: f32 = 0.09;
 pub const OUTLINE_THICKNESS: f32 = 0.02;
-pub const OUTLINE_MARGIN: f32 = 0.005;
+pub const OUTLINE_MARGIN: f32 = 0.0005;
 
 const GAMMA: f32 = 2.2;
 

--- a/src/render/machine.rs
+++ b/src/render/machine.rs
@@ -390,8 +390,8 @@ pub fn render_block(
                     * if let Some(wind_anim_state) = wind_anim_state.as_ref() {
                         if wind_anim_state.num_alive_in() > 0 && wind_anim_state.num_alive_out() > 0
                         {
-                            1.0 + 0.1
-                                * (tick_time.tick_progress() * 2.0 * std::f32::consts::PI)
+                            1.0 + 0.05
+                                * (tick_time.tick_progress() * std::f32::consts::PI)
                                     .sin()
                                     .powf(2.0)
                         } else {

--- a/src/render/object.rs
+++ b/src/render/object.rs
@@ -271,10 +271,10 @@ impl Object {
                 let mut indices = Vec::new();
 
                 // Number of subdivisions along the x axis
-                let n = 64;
+                let n = 32;
 
                 // Number of subdivisions along the angle
-                let m = 12;
+                let m = 8;
 
                 // Add positions and normals
                 for i in 0..n+1 {

--- a/src/render/pipeline/deferred/shader.rs
+++ b/src/render/pipeline/deferred/shader.rs
@@ -142,7 +142,7 @@ pub fn composition_core_transform(
         .with_extra_uniform(("light_texture".into(), UniformType::Sampler2d));
 
     let light_expr = "texture(light_texture, v_tex_coord).rgb";
-    let ambient_expr = "vec3(0.3, 0.3, 0.3)";
+    let ambient_expr = "vec3(0.1, 0.1, 0.1)";
 
     let fragment = if have_shadows {
         fragment

--- a/src/render/pipeline/glow/mod.rs
+++ b/src/render/pipeline/glow/mod.rs
@@ -20,7 +20,7 @@ pub struct Config {
 
 impl Default for Config {
     fn default() -> Self {
-        Self { num_blur_passes: 5 }
+        Self { num_blur_passes: 2 }
     }
 }
 

--- a/src/render/pipeline/light.rs
+++ b/src/render/pipeline/light.rs
@@ -9,7 +9,7 @@ pub struct Light {
     pub position: na::Point3<f32>,
     pub attenuation: na::Vector3<f32>,
     pub color: na::Vector3<f32>,
-    pub radius: f32,
+    pub is_main: bool,
 }
 
 impl InstanceParams for Light {
@@ -24,7 +24,7 @@ impl InstanceParams for Light {
             light_position: position,
             light_attenuation: attenuation,
             light_color: color,
-            light_radius: self.radius,
+            light_is_main: self.is_main,
         }
     }
 }
@@ -35,7 +35,7 @@ impl Default for Light {
             position: na::Point3::origin(),
             attenuation: na::Vector3::zeros(),
             color: na::Vector3::zeros(),
-            radius: 1.0,
+            is_main: false,
         }
     }
 }

--- a/src/render/pipeline/mod.rs
+++ b/src/render/pipeline/mod.rs
@@ -308,7 +308,6 @@ impl Components {
             depth_texture,
         )?;
 
-        // TODO: Fix cylinder so that we can reenable backface culling
         let params = glium::DrawParameters {
             backface_culling: glium::draw_parameters::BackfaceCullingMode::CullClockwise,
             depth: glium::Depth {

--- a/src/render/pipeline/mod.rs
+++ b/src/render/pipeline/mod.rs
@@ -484,20 +484,10 @@ impl Pipeline {
         facade: &F,
         resources: &Resources,
         context: &Context,
-        render_lists: &mut RenderLists,
+        render_lists: &RenderLists,
         target: &mut S,
     ) -> Result<(), DrawError> {
         profile!("pipeline");
-
-        if self.components.deferred_shading.is_some() {
-            render_lists.lights.push(Light {
-                position: context.main_light_pos,
-                attenuation: na::Vector3::new(1.0, 0.0, 0.0),
-                color: na::Vector3::new(1.0, 1.0, 1.0),
-                //color: na::Vector3::new(0.5, 0.5, 0.8) * 2.0,
-                radius: 160.0,
-            });
-        }
 
         // Clear buffers
         {

--- a/src/render/pipeline/mod.rs
+++ b/src/render/pipeline/mod.rs
@@ -315,6 +315,7 @@ impl Components {
                 write: true,
                 ..Default::default()
             },
+            line_width: Some(2.0),
             ..Default::default()
         };
 

--- a/src/render/pipeline/mod.rs
+++ b/src/render/pipeline/mod.rs
@@ -363,8 +363,9 @@ pub struct Pipeline {
 
     scene_pass_solid: ScenePass<DefaultInstanceParams, object::Vertex>,
     scene_pass_solid_glow: ScenePass<DefaultInstanceParams, object::Vertex>,
-    scene_pass_plain: ScenePass<DefaultInstanceParams, object::Vertex>,
     scene_pass_wind: ScenePass<wind::Params, object::Vertex>,
+
+    scene_pass_plain: ScenePass<DefaultInstanceParams, object::Vertex>,
 
     scene_color_texture: glium::texture::Texture2d,
     scene_depth_texture: glium::texture::DepthTexture2d,
@@ -402,14 +403,6 @@ impl Pipeline {
             },
             simple::plain_scene_core(),
         )?;
-        let scene_pass_plain = components.create_scene_pass(
-            facade,
-            ScenePassSetup {
-                shadow: false,
-                glow: false,
-            },
-            simple::plain_scene_core(),
-        )?;
         let scene_pass_wind = components.create_scene_pass(
             facade,
             ScenePassSetup {
@@ -418,6 +411,19 @@ impl Pipeline {
             },
             wind::scene_core(),
         )?;
+
+        let plain_core = simple::plain_scene_core();
+        let plain_program = plain_core
+            .build_program(facade)
+            .map_err(render::CreationError::from)?;
+        let scene_pass_plain = ScenePass {
+            setup: ScenePassSetup {
+                shadow: false,
+                glow: false,
+            },
+            shader_core: plain_core,
+            program: plain_program,
+        };
 
         let rounded_size: (u32, u32) = view_config.window_size.into();
         let scene_color_texture = Self::create_color_texture(facade, rounded_size)?;

--- a/src/render/pipeline/shadow/shader.rs
+++ b/src/render/pipeline/shadow/shader.rs
@@ -81,7 +81,7 @@ pub fn render_shadowed_core_transform<P: InstanceParams, V: glium::vertex::Verte
                 float closest_depth = texture(shadow_map, proj_coords.xy).r;
                 float current_depth = proj_coords.z;
 
-                return current_depth > closest_depth ? 0.75 : 1.0;
+                return current_depth > closest_depth ? 0.0 : 1.0;
             }
             ",
         )

--- a/src/render/pipeline/shadow/shader.rs
+++ b/src/render/pipeline/shadow/shader.rs
@@ -81,7 +81,7 @@ pub fn render_shadowed_core_transform<P: InstanceParams, V: glium::vertex::Verte
                 float closest_depth = texture(shadow_map, proj_coords.xy).r;
                 float current_depth = proj_coords.z;
 
-                return current_depth > closest_depth ? 0.0 : 1.0;
+                return current_depth > closest_depth ? 0.5 : 1.0;
             }
             ",
         )

--- a/src/render/pipeline/wind.rs
+++ b/src/render/pipeline/wind.rs
@@ -101,7 +101,7 @@ pub fn scene_core() -> shader::Core<(Context, Params), object::Vertex> {
 
             float x = 0.5 - position.x;
 
-            if (x < start || x > end)
+            if (x < start || x > end || start == end)
                 v_discard = 1.0;
             else
                 v_discard = 0.0;

--- a/src/render/pipeline/wind.rs
+++ b/src/render/pipeline/wind.rs
@@ -64,8 +64,8 @@ pub fn scene_core() -> shader::Core<(Context, Params), object::Vertex> {
         ],
         defs: "
             const float PI = 3.141592;
-            const float radius = 0.05;
-            const float scale = 0.0075;
+            const float radius = 0.04;
+            const float scale = 0.0105;
         "
         .to_string(),
         body: "

--- a/src/render/pipeline/wind.rs
+++ b/src/render/pipeline/wind.rs
@@ -69,7 +69,10 @@ pub fn scene_core() -> shader::Core<(Context, Params), object::Vertex> {
         "
         .to_string(),
         body: "
-            float angle = (position.x + 0.5 + 2.0 * tick_progress) * 1.0 * PI + phase;
+            float angle = (position.x + 0.5) * PI
+                + tick_progress * PI / 2.0
+                + phase;
+
             float rot_s = sin(angle);
             float rot_c = cos(angle);
             mat2 rot_m = mat2(rot_c, -rot_s, rot_s, rot_c);
@@ -77,19 +80,6 @@ pub fn scene_core() -> shader::Core<(Context, Params), object::Vertex> {
             vec3 scaled_pos = position;
             scaled_pos.yz *= scale;
             scaled_pos.z += radius;
-
-            if (bend) {
-                // Currently unused, for wind bending
-                float tau = (0.5 - position.x) * PI / 2.0;
-                scaled_pos.x = 0.5 * cos(tau);
-                scaled_pos.y += 0.5 * sin(tau);
-
-                vec3 normal = vec3(cos(tau), sin(tau), 0.0);
-                scaled_pos += normal * sin(angle) * 0.05;
-            }
-
-            //scaled_pos.y += sin(angle) * radius;
-            //scaled_pos.z += cos(angle) * radius;
 
             vec3 rot_normal = normal;
             scaled_pos.yz = rot_m * scaled_pos.yz;


### PR DESCRIPTION
- Proof of concept for outlines, using `GL_LINES` for now. Looks derpy when zooming out and is missing pipes.
- Play around with colors

- Wind:
  - Winding four times slower!
  - Add stripes to indicate directions
- Pipeline:
  - Shadows no longer override secondary lights
  - Plain instances are now rendered _after_ composition