### PR TITLE
Simplify editor piece

### DIFF
--- a/src/edit/editor/action.rs
+++ b/src/edit/editor/action.rs
@@ -67,7 +67,7 @@ impl Editor {
 
             // Bias towards positive direction for even sizes.
             // Just feels more natural.
-            // TODO: Bias actually needs to depends on the view position?
+            // TODO: Bias actually needs to depend on the view position?
             if extent.x > 0 && extent.x % 2 == 0 {
                 piece.shift(&grid::Vector3::x());
             }

--- a/src/edit/mode.rs
+++ b/src/edit/mode.rs
@@ -36,22 +36,14 @@ pub enum Mode {
 
     PlacePiece {
         piece: Piece,
-        offset: grid::Vector3,
     },
 
     DragAndDrop {
-        /// Selection that is being dragged. No duplicate positions, and each
-        /// must contain a block in the machine.
+        /// Blocks that were selected at the time of starting drag-and-drop.
+        /// Used for returning to selection mode if drag-and-drop is aborted.
         selection: Vec<grid::Point3>,
 
-        /// Position that is being dragged, i.e. the block that was grabbed by
-        /// the user.
-        center_pos: grid::Point3,
-
-        /// Rotation to be applied to the piece.
-        rotation_xy: usize,
-
-        layer_offset: isize,
+        piece: Piece,
     },
 
     PipeTool {
@@ -120,24 +112,10 @@ impl Mode {
             }
             Mode::DragAndDrop {
                 mut selection,
-                center_pos,
-                rotation_xy,
-                layer_offset,
+                piece,
             } => {
                 selection.retain(|grid_pos| machine.get_block_at_pos(grid_pos).is_some());
-
-                if !selection.contains(&center_pos) {
-                    // If the center block is not selected anymore, let's just
-                    // not bother with this.
-                    Mode::new_selection(selection)
-                } else {
-                    Mode::DragAndDrop {
-                        selection,
-                        center_pos,
-                        rotation_xy,
-                        layer_offset,
-                    }
-                }
+                Mode::DragAndDrop { selection, piece }
             }
             mode => mode,
         }

--- a/src/edit/piece.rs
+++ b/src/edit/piece.rs
@@ -72,20 +72,18 @@ impl Piece {
     }
 
     pub fn rotate_cw_xy(&mut self) {
-        self.blocks = Self::blocks_to_origin(
-            &self
-                .blocks
-                .clone()
-                .into_iter()
-                .map(|(p, mut placed_block)| {
-                    let rotated_p = grid::Point3::new(p.y, self.grid_size().y - p.x, p.z);
+        self.blocks = self
+            .blocks
+            .clone()
+            .into_iter()
+            .map(|(p, mut placed_block)| {
+                let rotated_p = grid::Point3::new(p.y, self.grid_size().x - p.x - 1, p.z);
 
-                    placed_block.block.mutate_dirs(|dir| dir.rotated_cw_xy());
+                placed_block.block.mutate_dirs(|dir| dir.rotated_cw_xy());
 
-                    (rotated_p, placed_block)
-                })
-                .collect::<Vec<_>>(),
-        );
+                (rotated_p, placed_block)
+            })
+            .collect::<Vec<_>>();
     }
 
     pub fn rotate_ccw_xy(&mut self) {
@@ -95,26 +93,24 @@ impl Piece {
     }
 
     pub fn mirror_y(&mut self) {
-        self.blocks = Self::blocks_to_origin(
-            &self
-                .blocks
-                .clone()
-                .into_iter()
-                .map(|(p, mut placed_block)| {
-                    let mirrored_p = grid::Point3::new(self.grid_size().x - p.x, p.y, p.z);
+        self.blocks = self
+            .blocks
+            .clone()
+            .into_iter()
+            .map(|(p, mut placed_block)| {
+                let mirrored_p = grid::Point3::new(self.grid_size().x - p.x - 1, p.y, p.z);
 
-                    placed_block.block.mutate_dirs(|dir| {
-                        if dir.0 == grid::Axis3::X {
-                            dir.invert()
-                        } else {
-                            dir
-                        }
-                    });
+                placed_block.block.mutate_dirs(|dir| {
+                    if dir.0 == grid::Axis3::X {
+                        dir.invert()
+                    } else {
+                        dir
+                    }
+                });
 
-                    (mirrored_p, placed_block)
-                })
-                .collect::<Vec<_>>(),
-        );
+                (mirrored_p, placed_block)
+            })
+            .collect::<Vec<_>>();
     }
 
     pub fn next_kind(&mut self) {

--- a/src/edit/piece.rs
+++ b/src/edit/piece.rs
@@ -6,8 +6,6 @@ use crate::machine::{Machine, PlacedBlock};
 /// clipboard and stuff like that.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Piece {
-    /// Blocks that shall be placed. All point coordinates are assumed to be
-    /// non-negative.
     blocks: Vec<(grid::Point3, PlacedBlock)>,
 }
 
@@ -18,144 +16,27 @@ impl Piece {
         }
     }
 
-    pub fn new_blocks_to_origin(blocks: &[(grid::Point3, PlacedBlock)]) -> Self {
-        Self {
-            blocks: Self::blocks_to_origin(blocks),
-        }
+    pub fn new(blocks: Vec<(grid::Point3, PlacedBlock)>) -> Self {
+        Piece { blocks }
     }
 
     pub fn new_from_selection(
         machine: &Machine,
         selection: impl Iterator<Item = grid::Point3>,
     ) -> Self {
-        Piece::new_blocks_to_origin(&Self::selected_blocks(machine, selection).collect::<Vec<_>>())
+        let blocks = selection.filter_map(|pos| {
+            machine
+                .get_block_at_pos(&pos)
+                .map(|(_, block)| (pos, block.clone()))
+        });
+
+        Self::new(blocks.collect())
     }
 
-    pub fn block_at_index(&self, index: usize) -> &(grid::Point3, PlacedBlock) {
-        &self.blocks[index]
-    }
-
-    pub fn selected_blocks<'a>(
-        machine: &'a Machine,
-        selection: impl Iterator<Item = grid::Point3> + 'a,
-    ) -> impl Iterator<Item = (grid::Point3, PlacedBlock)> + 'a {
-        selection.filter_map(move |p| machine.get_block_at_pos(&p).map(|(_, b)| (p, b.clone())))
-    }
-
-    pub fn grid_size(&self) -> grid::Vector3 {
-        let mut max = grid::Vector3::zeros();
-
-        for (p, _) in self.blocks.iter() {
-            if p.x > max.x {
-                max.x = p.x;
-            }
-            if p.y > max.y {
-                max.y = p.y;
-            }
-            if p.z > max.z {
-                max.z = p.z;
-            }
-        }
-
-        max + grid::Vector3::new(1, 1, 1)
-    }
-
-    pub fn grid_center_xy(&self) -> grid::Vector3 {
-        let size = self.grid_size();
-
-        // Bias towards the origin for even sizes
-        grid::Vector3::new(
-            size.x / 2 - (size.x > 0 && size.x % 2 == 0) as isize,
-            size.y / 2 - (size.y > 0 && size.y % 2 == 0) as isize,
-            0,
-        )
-    }
-
-    pub fn rotate_cw_xy(&mut self) {
-        self.blocks = self
-            .blocks
-            .clone()
-            .into_iter()
-            .map(|(p, mut placed_block)| {
-                let rotated_p = grid::Point3::new(p.y, self.grid_size().x - p.x - 1, p.z);
-
-                placed_block.block.mutate_dirs(|dir| dir.rotated_cw_xy());
-
-                (rotated_p, placed_block)
-            })
-            .collect::<Vec<_>>();
-    }
-
-    pub fn rotate_ccw_xy(&mut self) {
-        for _ in 0..3 {
-            self.rotate_cw_xy();
-        }
-    }
-
-    pub fn mirror_y(&mut self) {
-        self.blocks = self
-            .blocks
-            .clone()
-            .into_iter()
-            .map(|(p, mut placed_block)| {
-                let mirrored_p = grid::Point3::new(self.grid_size().x - p.x - 1, p.y, p.z);
-
-                placed_block.block.mutate_dirs(|dir| {
-                    if dir.0 == grid::Axis3::X {
-                        dir.invert()
-                    } else {
-                        dir
-                    }
-                });
-
-                (mirrored_p, placed_block)
-            })
-            .collect::<Vec<_>>();
-    }
-
-    pub fn next_kind(&mut self) {
-        for (_, placed_block) in self.blocks.iter_mut() {
-            if let Some(kind) = placed_block.block.kind() {
-                placed_block.block.set_kind(kind.next());
-            }
-        }
-    }
-
-    pub fn place_edit(&self, offset: &grid::Vector3) -> Edit {
-        let set_blocks = self
-            .iter_blocks(offset)
-            .map(|(pos, block)| (pos, Some(block)))
-            .collect();
-
-        Edit::SetBlocks(set_blocks)
-    }
-
-    pub fn iter_blocks(
-        &self,
-        offset: &grid::Vector3,
-    ) -> impl Iterator<Item = (grid::Point3, PlacedBlock)> + '_ {
-        let offset = *offset;
-        self.blocks
-            .iter()
-            .map(move |(pos, block)| (pos + offset, block.clone()))
-    }
-
-    pub fn get_singleton(&self) -> Option<(grid::Point3, PlacedBlock)> {
-        if let Some(entry) = self.blocks.iter().next() {
-            if self.blocks.len() == 1 {
-                Some(entry.clone())
-            } else {
-                None
-            }
-        } else {
-            None
-        }
-    }
-
-    pub fn blocks_min_pos(blocks: &[(grid::Point3, PlacedBlock)]) -> grid::Point3 {
+    pub fn min_pos(&self) -> grid::Point3 {
         let mut min = grid::Point3::new(std::isize::MAX, std::isize::MAX, std::isize::MAX);
 
-        for (p, _) in blocks {
+        for (p, _) in &self.blocks {
             if p.x < min.x {
                 min.x = p.x;
             }
@@ -170,14 +51,90 @@ impl Piece {
         min
     }
 
-    pub fn blocks_to_origin(
-        blocks: &[(grid::Point3, PlacedBlock)],
-    ) -> Vec<(grid::Point3, PlacedBlock)> {
-        let min = Self::blocks_min_pos(blocks);
+    pub fn max_pos(&self) -> grid::Point3 {
+        let mut max = grid::Point3::new(std::isize::MIN, std::isize::MIN, std::isize::MIN);
 
-        blocks
-            .iter()
-            .map(|(p, block)| (p - min.coords, block.clone()))
-            .collect()
+        for (p, _) in &self.blocks {
+            if p.x > max.x {
+                max.x = p.x;
+            }
+            if p.y > max.y {
+                max.y = p.y;
+            }
+            if p.z > max.z {
+                max.z = p.z;
+            }
+        }
+
+        max
+    }
+
+    pub fn extent(&self) -> grid::Vector3 {
+        self.max_pos() - self.min_pos() + grid::Vector3::new(1, 1, 1)
+    }
+
+    pub fn shift(&mut self, delta: &grid::Vector3) {
+        for (pos, _) in self.blocks.iter_mut() {
+            *pos += delta;
+        }
+    }
+
+    pub fn rotate_cw_xy(&mut self) {
+        for (pos, placed_block) in self.blocks.iter_mut() {
+            *pos = grid::Point3::new(pos.y, -pos.x, pos.z);
+            placed_block.block.mutate_dirs(grid::Dir3::rotated_cw_xy);
+        }
+    }
+
+    pub fn rotate_ccw_xy(&mut self) {
+        for _ in 0..3 {
+            self.rotate_cw_xy();
+        }
+    }
+
+    pub fn mirror_y(&mut self) {
+        let max_pos = self.max_pos();
+
+        for (pos, placed_block) in self.blocks.iter_mut() {
+            *pos = grid::Point3::new(max_pos.x - pos.x - 1, pos.y, pos.z);
+
+            placed_block.block.mutate_dirs(|dir| {
+                if dir.0 == grid::Axis3::X {
+                    dir.invert()
+                } else {
+                    dir
+                }
+            });
+        }
+    }
+
+    pub fn set_next_kind(&mut self) {
+        for (_, placed_block) in self.blocks.iter_mut() {
+            if let Some(kind) = placed_block.block.kind() {
+                placed_block.block.set_kind(kind.next());
+            }
+        }
+    }
+
+    pub fn as_place_edit(&self) -> Edit {
+        let set_blocks = self.iter().map(|(pos, block)| (pos, Some(block))).collect();
+
+        Edit::SetBlocks(set_blocks)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (grid::Point3, PlacedBlock)> + '_ {
+        self.blocks.iter().map(|(pos, block)| (*pos, block.clone()))
+    }
+
+    pub fn get_singleton(&self) -> Option<(grid::Point3, PlacedBlock)> {
+        if let Some(entry) = self.blocks.iter().next() {
+            if self.blocks.len() == 1 {
+                Some(entry.clone())
+            } else {
+                None
+            }
+        } else {
+            None
+        }
     }
 }


### PR DESCRIPTION
`Piece` now allows negative positions by design. This allows simplifications:
- `Mode::PlacePiece` no longer needs to store an offset for centering the piece
- `Mode::DragAndDrop` can store `Piece` for placing, since we simply shift the dragged position to the origin. (Previously, `Mode::DragAndDrop` stored the dragged position, a rotation count and then in each frame manually determined a `Piece` from the selection. This logic was needlessly complicated.)