### PR TITLE
Execution tests

### DIFF
--- a/src/edit/editor/action.rs
+++ b/src/edit/editor/action.rs
@@ -61,7 +61,8 @@ impl Editor {
             let mut piece = clipboard.clone();
 
             // Kinda center the piece at the mouse
-            let extent = piece.extent();
+            let mut extent = piece.extent();
+            extent.z = 0;
 
             piece.shift(&(-piece.min_pos().coords - extent / 2));
 

--- a/src/edit/editor/mod.rs
+++ b/src/edit/editor/mod.rs
@@ -382,9 +382,9 @@ impl Editor {
                 }
 
                 if blocks.get(&mouse_grid_pos).is_none() {
-                    let existing_new_block = self.machine.get_block_at_pos(&mouse_grid_pos);
+                    let existing_new_block = self.machine.get(&mouse_grid_pos);
 
-                    if let Some((_, existing_new_block)) = existing_new_block {
+                    if let Some(existing_new_block) = existing_new_block {
                         blocks.insert(mouse_grid_pos, existing_new_block.clone());
                     }
                 }
@@ -544,10 +544,9 @@ impl Editor {
 
                 if let Some(mouse_grid_pos) = mouse_grid_pos {
                     // Don't overwrite existing block when starting placement
-                    let blocks = if let Some(block) = self.machine.get_block_at_pos(&mouse_grid_pos)
-                    {
+                    let blocks = if let Some(block) = self.machine.get(&mouse_grid_pos) {
                         maplit::hashmap! {
-                            mouse_grid_pos => block.1.clone(),
+                            mouse_grid_pos => block.clone(),
                         }
                     } else {
                         let mut block = Block::Pipe(grid::Dir3::Y_NEG, grid::Dir3::Y_POS);
@@ -581,9 +580,7 @@ impl Editor {
     ) -> Mode {
         // Double check that there actually is a block at the mouse block
         // position.
-        let block_pos = self
-            .mouse_block_pos
-            .filter(|p| self.machine.get_block_at_pos(p).is_some());
+        let block_pos = self.mouse_block_pos.filter(|p| self.machine.is_block_at(p));
 
         if let Some(block_pos) = block_pos {
             // Clicked on a block!
@@ -711,8 +708,8 @@ impl Editor {
                         .unwrap_or(false);
                     let existing = self
                         .machine
-                        .get_block_at_pos(&(pos + dir.to_vector()))
-                        .map(|(_, neighbor)| neighbor.has_wind_hole(dir.invert()))
+                        .get(&(pos + dir.to_vector()))
+                        .map(|neighbor| neighbor.has_wind_hole(dir.invert()))
                         .unwrap_or(false);
 
                     tentative || existing

--- a/src/edit/editor/render.rs
+++ b/src/edit/editor/render.rs
@@ -114,9 +114,7 @@ impl Editor {
                             out,
                         );
 
-                        if last_pos.is_none()
-                            && self.machine.get_block_at_pos(&mouse_grid_pos).is_none()
-                        {
+                        if last_pos.is_none() && self.machine.get(&mouse_grid_pos).is_none() {
                             let mut block = Block::Pipe(grid::Dir3::Y_NEG, grid::Dir3::Y_POS);
                             for _ in 0..*rotation_xy {
                                 block.mutate_dirs(|dir| dir.rotated_cw_xy());
@@ -234,9 +232,7 @@ impl Editor {
                     &na::Vector4::new(0.5, 0.5, 0.5, 1.0),
                     out,
                 );
-            } else if !self.machine.is_valid_pos(&pos)
-                || self.machine.get_block_at_pos(&pos).is_some()
-            {
+            } else if !self.machine.is_valid_pos(&pos) || self.machine.is_block_at(&pos) {
                 self.render_block_wireframe(
                     &pos,
                     0.020,

--- a/src/edit/mod.rs
+++ b/src/edit/mod.rs
@@ -43,21 +43,14 @@ impl Edit {
 
                 let previous_blocks = valid_blocks
                     .keys()
-                    .map(|p| {
-                        (
-                            *p,
-                            machine
-                                .get_block_at_pos(p)
-                                .map(|(_index, block)| block.clone()),
-                        )
-                    })
+                    .map(|p| (*p, machine.get(p).cloned()))
                     .collect();
 
                 if previous_blocks == valid_blocks {
                     Edit::NoOp
                 } else {
                     for (p, block) in valid_blocks.iter() {
-                        machine.set_block_at_pos(p, block.clone());
+                        machine.set(p, block.clone());
                     }
 
                     Edit::SetBlocks(previous_blocks)
@@ -65,7 +58,7 @@ impl Edit {
             }
             Edit::RotateCWXY(points) => {
                 for p in &points {
-                    if let Some((_, placed_block)) = machine.get_block_at_pos_mut(p) {
+                    if let Some(placed_block) = machine.get_mut(p) {
                         placed_block.block.mutate_dirs(|dir| dir.rotated_cw_xy());
                     }
                 }
@@ -78,7 +71,7 @@ impl Edit {
             }
             Edit::RotateCCWXY(points) => {
                 for p in &points {
-                    if let Some((_, placed_block)) = machine.get_block_at_pos_mut(p) {
+                    if let Some(placed_block) = machine.get_mut(p) {
                         placed_block.block.mutate_dirs(|dir| dir.rotated_ccw_xy());
                     }
                 }

--- a/src/edit/mode.rs
+++ b/src/edit/mode.rs
@@ -95,7 +95,7 @@ impl Mode {
     pub fn make_consistent_with_machine(self, machine: &Machine) -> Self {
         match self {
             Mode::Select { mut selection } => {
-                selection.retain(|grid_pos| machine.get_block_at_pos(grid_pos).is_some());
+                selection.retain(|grid_pos| machine.is_block_at(grid_pos));
 
                 Mode::Select { selection }
             }
@@ -104,9 +104,9 @@ impl Mode {
                 dragged_block_pos,
                 dragged_grid_pos,
             } => {
-                selection.retain(|grid_pos| machine.get_block_at_pos(grid_pos).is_some());
+                selection.retain(|grid_pos| machine.is_block_at(grid_pos));
 
-                if machine.get_block_at_pos(&dragged_block_pos).is_none() {
+                if !machine.is_block_at(&dragged_block_pos) {
                     // The block that the user want to drag-and-drop was
                     // removed; give up on dragging.
                     Mode::Select { selection }
@@ -125,8 +125,8 @@ impl Mode {
                 start_pos,
                 end_pos,
             } => {
-                existing_selection.retain(|grid_pos| machine.get_block_at_pos(grid_pos).is_some());
-                new_selection.retain(|grid_pos| machine.get_block_at_pos(grid_pos).is_some());
+                existing_selection.retain(|grid_pos| machine.is_block_at(grid_pos));
+                new_selection.retain(|grid_pos| machine.is_block_at(grid_pos));
 
                 Mode::RectSelect {
                     existing_selection,
@@ -139,7 +139,7 @@ impl Mode {
                 mut selection,
                 piece,
             } => {
-                selection.retain(|grid_pos| machine.get_block_at_pos(grid_pos).is_some());
+                selection.retain(|grid_pos| machine.is_block_at(grid_pos));
 
                 Mode::DragAndDrop { selection, piece }
             }

--- a/src/edit/pick.rs
+++ b/src/edit/pick.rs
@@ -117,7 +117,7 @@ pub fn pick_line(machine: &Machine, a: &grid::Point3, b: &grid::Point3) -> Vec<g
         // We remove duplicates in a simple and costly way here that allows us
         // to keep the order (if b is included it should always be the last
         // element). We expect `points` to be relatively small anyway.
-        if machine.get_block_at_pos(&c).is_some() && !points.contains(&c) {
+        if machine.is_block_at(&c) && !points.contains(&c) {
             points.push(c);
         }
     }

--- a/src/edit/piece.rs
+++ b/src/edit/piece.rs
@@ -27,6 +27,14 @@ impl<'a> Mul<grid::Point3> for &'a Transform {
     }
 }
 
+impl<'a> Mul<(isize, isize, isize)> for &'a Transform {
+    type Output = grid::Point3;
+
+    fn mul(self, p: (isize, isize, isize)) -> grid::Point3 {
+        self * grid::Point3::new(p.0, p.1, p.2)
+    }
+}
+
 impl<'a> Mul<grid::Dir3> for &'a Transform {
     type Output = grid::Dir3;
 
@@ -74,6 +82,10 @@ impl Piece {
 
     pub fn iter(&self) -> impl Iterator<Item = (grid::Point3, PlacedBlock)> + '_ {
         self.blocks.iter().map(|(pos, block)| (*pos, block.clone()))
+    }
+
+    pub fn blocks(&self) -> &[(grid::Point3, PlacedBlock)] {
+        &self.blocks
     }
 
     pub fn transform(&mut self, transform: &Transform) {

--- a/src/edit/piece.rs
+++ b/src/edit/piece.rs
@@ -71,11 +71,8 @@ impl Piece {
         machine: &Machine,
         selection: impl Iterator<Item = grid::Point3>,
     ) -> Self {
-        let blocks = selection.filter_map(|pos| {
-            machine
-                .get_block_at_pos(&pos)
-                .map(|(_, block)| (pos, block.clone()))
-        });
+        let blocks =
+            selection.filter_map(|pos| machine.get(&pos).map(|block| (pos, block.clone())));
 
         Self::new(blocks.collect())
     }

--- a/src/exec/anim.rs
+++ b/src/exec/anim.rs
@@ -73,7 +73,7 @@ impl WindAnimState {
 
             // Incoming wind
             let neighbor_pos = machine.block_pos_at_index(block_index) + dir.to_vector();
-            let neighbor_block = machine.get_block_at_pos(&neighbor_pos);
+            let neighbor_block = machine.get_with_index(&neighbor_pos);
             if let Some((neighbor_index, neighbor_block)) = neighbor_block {
                 // If neighboring block has no wind connection in this
                 // direction, we won't show wind.

--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -1,6 +1,8 @@
 pub mod anim;
 pub mod level_progress;
 pub mod play;
+#[cfg(test)]
+mod tests;
 pub mod view;
 
 use std::iter;

--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -156,6 +156,10 @@ impl Exec {
         &self.old_wind_state
     }
 
+    pub fn blip_state(&self) -> &[BlipState] {
+        &self.blip_state
+    }
+
     pub fn blips(&self) -> &VecOption<Blip> {
         &self.blips
     }
@@ -504,7 +508,9 @@ impl Exec {
             let block_index = block_indices[blip.pos].unwrap();
             let blip_index_in_block = self.blip_state[block_index].blip_index;
 
-            if blip.status != BlipStatus::Dying {
+            if blip.status != BlipStatus::Dying
+                && blip.status != BlipStatus::Spawning(BlipSpawnMode::LiveToDie)
+            {
                 debug_assert_eq!(
                     blip_index_in_block,
                     Some(blip_index),

--- a/src/exec/tests.rs
+++ b/src/exec/tests.rs
@@ -21,25 +21,25 @@ fn test_straight_wind_propagation() {
 
             // Wind source has outgoing wind everywhere.
             for &d in &Dir3::ALL {
-                assert!(wind(exec, t * (0, 0, 0)).wind_out(d));
+                assert!(wind_out(exec, t * (0, 0, 0), d));
             }
 
             // Pipe has outgoing wind to the right.
             for x in 1..=i.min(10) {
-                assert!(wind(exec, t * (x, 0, 0)).wind_out(t * Dir3::X_POS));
+                assert!(wind_out(exec, t * (x, 0, 0), t * Dir3::X_POS));
             }
 
             // To the right, there is no wind yet.
             for x in i + 1..=10 {
                 for &d in &Dir3::ALL {
-                    assert!(!wind(exec, t * (x, 0, 0)).wind_out(d));
+                    assert!(!wind_out(exec, t * (x, 0, 0), d));
                 }
             }
 
             // And to the bottom, there never is any wind.
             for x in 0..=10 {
                 for &d in &Dir3::ALL {
-                    assert!(!wind(exec, t * (x, 1, 0)).wind_out(d));
+                    assert!(!wind_out(exec, t * (x, 1, 0), d));
                 }
             }
         }
@@ -60,13 +60,13 @@ fn test_funnel_wind_propagation() {
 
             // Pipes up to the funnel get outgoing wind (after some time).
             for x in 1..i.min(5) {
-                assert!(wind(exec, t * (x, 0, 0)).wind_out(t * Dir3::X_POS));
+                assert!(wind_out(exec, t * (x, 0, 0), t * Dir3::X_POS));
             }
 
             // The funnel and pipes to the right never have any outgoing wind.
             for x in 5..=10 {
                 for &d in &Dir3::ALL {
-                    assert!(!wind(exec, t * (x, 0, 0)).wind_out(d));
+                    assert!(!wind_out(exec, t * (x, 0, 0), d));
                 }
             }
         }
@@ -91,18 +91,18 @@ fn test_merge_xy_wind_propagation() {
 
             // Flow to the right.
             for x in 1..=i.min(10) {
-                assert!(wind(exec, t * (x, 2, 0)).wind_out(t * Dir3::X_POS));
+                assert!(wind_out(exec, t * (x, 2, 0), t * Dir3::X_POS));
             }
 
             // Flow up starts after 9 updates.
-            assert_eq!(wind(exec, t * (8, 2, 0)).wind_out(t * Dir3::Y_NEG), i >= 8);
-            assert_eq!(wind(exec, t * (8, 1, 0)).wind_out(t * Dir3::Y_NEG), i >= 9);
-            assert_eq!(wind(exec, t * (8, 0, 0)).wind_out(t * Dir3::Y_NEG), i >= 10);
+            assert_eq!(wind_out(exec, t * (8, 2, 0), t * Dir3::Y_NEG), i >= 8);
+            assert_eq!(wind_out(exec, t * (8, 1, 0), t * Dir3::Y_NEG), i >= 9);
+            assert_eq!(wind_out(exec, t * (8, 0, 0), t * Dir3::Y_NEG), i >= 10);
 
             // Flow down starts after 9 updates.
-            assert_eq!(wind(exec, t * (8, 2, 0)).wind_out(t * Dir3::Y_POS), i >= 8);
-            assert_eq!(wind(exec, t * (8, 3, 0)).wind_out(t * Dir3::Y_POS), i >= 9);
-            assert_eq!(wind(exec, t * (8, 4, 0)).wind_out(t * Dir3::Y_POS), i >= 10);
+            assert_eq!(wind_out(exec, t * (8, 2, 0), t * Dir3::Y_POS), i >= 8);
+            assert_eq!(wind_out(exec, t * (8, 3, 0), t * Dir3::Y_POS), i >= 9);
+            assert_eq!(wind_out(exec, t * (8, 4, 0), t * Dir3::Y_POS), i >= 10);
         }
     });
 }
@@ -133,47 +133,26 @@ fn test_wind_sliver_propagation() {
             for x in 1..=10 {
                 // Note that the blip wind source is at x=1, where wind flows
                 // out at i=2.
-                assert_eq!(
-                    wind(exec, t * (x, 2, 0)).wind_out(t * Dir3::X_POS),
-                    i == x + 1
-                );
+                assert_eq!(wind_out(exec, t * (x, 2, 0), t * Dir3::X_POS), i == x + 1);
             }
 
             // Flow up starts after 10 updates.
-            assert_eq!(
-                wind(exec, t * (8, 2, 0)).wind_out(t * Dir3::Y_NEG),
-                i == 8 + 1
-            );
-            assert_eq!(
-                wind(exec, t * (8, 1, 0)).wind_out(t * Dir3::Y_NEG),
-                i == 9 + 1
-            );
-            assert_eq!(
-                wind(exec, t * (8, 0, 0)).wind_out(t * Dir3::Y_NEG),
-                i == 10 + 1
-            );
+            assert_eq!(wind_out(exec, t * (8, 2, 0), t * Dir3::Y_NEG), i == 8 + 1);
+            assert_eq!(wind_out(exec, t * (8, 1, 0), t * Dir3::Y_NEG), i == 9 + 1);
+            assert_eq!(wind_out(exec, t * (8, 0, 0), t * Dir3::Y_NEG), i == 10 + 1);
 
             // Flow down starts after 10 updates.
-            assert_eq!(
-                wind(exec, t * (8, 2, 0)).wind_out(t * Dir3::Y_POS),
-                i == 8 + 1
-            );
-            assert_eq!(
-                wind(exec, t * (8, 3, 0)).wind_out(t * Dir3::Y_POS),
-                i == 9 + 1
-            );
-            assert_eq!(
-                wind(exec, t * (8, 4, 0)).wind_out(t * Dir3::Y_POS),
-                i == 10 + 1
-            );
+            assert_eq!(wind_out(exec, t * (8, 2, 0), t * Dir3::Y_POS), i == 8 + 1);
+            assert_eq!(wind_out(exec, t * (8, 3, 0), t * Dir3::Y_POS), i == 9 + 1);
+            assert_eq!(wind_out(exec, t * (8, 4, 0), t * Dir3::Y_POS), i == 10 + 1);
         }
     });
 }
 
-fn wind(exec: &Exec, p: grid::Point3) -> &WindState {
+fn wind_out(exec: &Exec, p: Point3, d: Dir3) -> bool {
     let (block_index, _block) = exec.machine().get_with_index(&p).unwrap();
 
-    &exec.wind_state()[block_index]
+    exec.wind_state()[block_index].wind_out(d)
 }
 
 fn test_transform_invariant<T>(blocks: &[(Point3, Block)], test: T)

--- a/src/exec/tests.rs
+++ b/src/exec/tests.rs
@@ -15,7 +15,7 @@ fn test_straight_wind_propagation() {
 ";
 
     test_transform_invariant(&blocks_from_string(m), |t, exec| {
-        for i in 0..=10 {
+        for i in 0..=20 {
             exec.update();
 
             // Wind source has outgoing wind everywhere.
@@ -24,14 +24,41 @@ fn test_straight_wind_propagation() {
             }
 
             // Pipe has outgoing wind to the right.
-            for j in 1..=i.min(10) {
-                assert!(wind(exec, t * (j, 0, 0)).wind_out(t * Dir3::X_POS));
+            for x in 1..=i.min(10) {
+                assert!(wind(exec, t * (x, 0, 0)).wind_out(t * Dir3::X_POS));
             }
 
             // To the right, there is no wind yet.
-            for j in i + 1..10 {
+            for x in i + 1..10 {
                 for &d in &Dir3::ALL {
-                    assert!(!wind(exec, t * (j, 0, 0)).wind_out(d));
+                    assert!(!wind(exec, t * (x, 0, 0)).wind_out(d));
+                }
+            }
+        }
+    });
+}
+
+/// Test that funnel propagates wind in only one direction.
+#[test]
+fn test_funnel_wind_propagation() {
+    // A wind source, followed by a funnel at x=5.
+    let m = "
+◉----▷-----
+";
+
+    test_transform_invariant(&blocks_from_string(m), |t, exec| {
+        for i in 0..20 {
+            exec.update();
+
+            // Pipes up to the funnel get outgoing wind (after some time).
+            for x in 1..i.min(5) {
+                assert!(wind(exec, t * (x, 0, 0)).wind_out(t * Dir3::X_POS));
+            }
+
+            // The funnel and pipes to the right never have any outgoing wind.
+            for x in 5..=10 {
+                for &d in &Dir3::ALL {
+                    assert!(!wind(exec, t * (x, 0, 0)).wind_out(d));
                 }
             }
         }

--- a/src/exec/tests.rs
+++ b/src/exec/tests.rs
@@ -1,0 +1,129 @@
+use rand::Rng;
+
+use crate::edit::piece::{Piece, Transform};
+use crate::exec::Exec;
+use crate::machine::grid::{Dir3, Point3, Vector3};
+use crate::machine::{grid, Block, Machine, PlacedBlock};
+
+use Block::*;
+
+type Blocks = [((isize, isize, isize), Block)];
+
+fn machine(blocks: &Blocks) -> Machine {
+    let blocks: Vec<(Point3, PlacedBlock)> = blocks
+        .iter()
+        .map(|(pos, block)| {
+            (
+                Point3::new(pos.0, pos.1, pos.2),
+                PlacedBlock {
+                    block: block.clone(),
+                },
+            )
+        })
+        .collect();
+    let size_x = blocks.iter().map(|(pos, _)| pos.x).max().unwrap() + 1;
+    let size_y = blocks.iter().map(|(pos, _)| pos.y).max().unwrap() + 1;
+    let size_z = blocks.iter().map(|(pos, _)| pos.z).max().unwrap() + 1;
+
+    Machine::new_from_block_data(&Vector3::new(size_x, size_y, size_z), &blocks, &None)
+}
+
+#[test]
+fn simple_wind() {
+    let b = machine(&[
+        ((0, 0, 0), Pipe(Dir3::X_NEG, Dir3::X_POS)),
+        ((0, 1, 0), Pipe(Dir3::X_NEG, Dir3::X_POS)),
+        ((0, 2, 0), Pipe(Dir3::X_NEG, Dir3::X_POS)),
+        ((0, 3, 0), Pipe(Dir3::X_NEG, Dir3::X_POS)),
+    ]);
+
+    assert!(true);
+}
+
+fn test_transform_invariance<T>(blocks: &Blocks, test: T)
+where
+    T: for<'a> Fn(&'a Transform, &'a mut Exec),
+{
+    let blocks = blocks
+        .iter()
+        .map(|(pos, block)| {
+            (
+                Point3::new(pos.0, pos.1, pos.2),
+                PlacedBlock {
+                    block: block.clone(),
+                },
+            )
+        })
+        .collect();
+    let piece = Piece::new(blocks);
+
+    for _ in 0..1000 {
+        let mut transform = random_transform();
+        let mut transformed_piece = piece.clone();
+        transformed_piece.transform(&transform);
+
+        // Make sure the blocks all have non-negative positions. This is currently a
+        // requirement for Machine.
+        let shift = random_shift_to_non_negative(&transformed_piece.min_pos());
+        transformed_piece.transform(&shift);
+        transform = Transform::Seq(vec![transform, shift]);
+
+        let size = transformed_piece.max_pos() + grid::Vector3::new(1, 1, 1);
+        let machine = Machine::new_from_block_data(&size.coords, transformed_piece.blocks(), &None);
+
+        let mut rng = rand::thread_rng();
+        let mut exec = Exec::new(machine, &mut rng);
+        test(&transform, &mut exec);
+    }
+}
+
+fn random_transform() -> Transform {
+    const MAX_TRANSFORMS: usize = 5;
+    const MAX_SHIFT_XY: isize = 100;
+    const MAX_SHIFT_Z: isize = 3;
+
+    let mut rng = rand::thread_rng();
+
+    let transforms = (0..rng.gen_range(0, MAX_TRANSFORMS))
+        .map(|_| match rng.gen_range(0, 4) {
+            0 => {
+                let x = rng.gen_range(-MAX_SHIFT_XY, MAX_SHIFT_XY);
+                let y = rng.gen_range(-MAX_SHIFT_XY, MAX_SHIFT_XY);
+                let z = rng.gen_range(-MAX_SHIFT_Z, MAX_SHIFT_Z);
+
+                Transform::Shift(grid::Vector3::new(x, y, z))
+            }
+            1 => Transform::RotateCWXY,
+            2 => Transform::RotateCCWXY,
+            3 => Transform::MirrorY,
+            _ => unreachable!(),
+        })
+        .collect();
+
+    Transform::Seq(transforms)
+}
+
+fn random_shift_to_non_negative(min_pos: &grid::Point3) -> Transform {
+    const MAX_SHIFT_XY: isize = 100;
+    const MAX_SHIFT_Z: isize = 3;
+
+    let mut rng = rand::thread_rng();
+
+    let shift_x = if min_pos.x < 0 {
+        -min_pos.x + rng.gen_range(0, MAX_SHIFT_XY)
+    } else {
+        0
+    };
+    let shift_y = if min_pos.y < 0 {
+        -min_pos.y + rng.gen_range(0, MAX_SHIFT_XY)
+    } else {
+        0
+    };
+    let shift_z = if min_pos.z < 0 {
+        -min_pos.z + rng.gen_range(0, MAX_SHIFT_Z)
+    } else {
+        0
+    };
+
+    Transform::Shift(grid::Vector3::new(shift_x, shift_y, shift_z))
+}

--- a/src/machine/grid.rs
+++ b/src/machine/grid.rs
@@ -127,6 +127,14 @@ impl Dir3 {
         Dir3(axis, sign)
     }
 
+    pub fn mirrored_y(self) -> Dir3 {
+        if self.0 == Axis3::X {
+            self.invert()
+        } else {
+            self
+        }
+    }
+
     /// Returns pitch and yaw to rotate an object that is oriented towards the x
     /// axis to point in our direction.
     ///

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -1,5 +1,6 @@
 pub mod grid;
 pub mod level;
+pub mod string_util;
 
 use std::fmt;
 

--- a/src/machine/string_util.rs
+++ b/src/machine/string_util.rs
@@ -1,0 +1,130 @@
+use crate::machine::grid::{Dir3, Point3};
+use crate::machine::{BlipKind, Block};
+
+pub fn blocks_from_string(s: &str) -> Vec<(Point3, Block)> {
+    s.lines()
+        .filter(|row| !row.trim().is_empty())
+        .enumerate()
+        .flat_map(|(y, row)| {
+            row.chars().enumerate().filter_map(move |(x, c)| {
+                block_from_char(c).map(|block| (Point3::new(x as isize, y as isize, 0), block))
+            })
+        })
+        .collect()
+}
+
+pub fn block_from_char(c: char) -> Option<Block> {
+    if c == '.' {
+        return None;
+    }
+
+    let block = match c {
+        '-' => Block::Pipe(Dir3::X_NEG, Dir3::X_POS),
+        '|' => Block::Pipe(Dir3::Y_NEG, Dir3::Y_POS),
+        '┘' => Block::Pipe(Dir3::X_NEG, Dir3::Y_NEG),
+        '┐' => Block::Pipe(Dir3::X_NEG, Dir3::Y_POS),
+        '└' => Block::Pipe(Dir3::Y_NEG, Dir3::X_POS),
+        '┌' => Block::Pipe(Dir3::Y_POS, Dir3::X_POS),
+
+        '┼' => Block::PipeMergeXY,
+
+        '▷' => Block::FunnelXY {
+            flow_dir: Dir3::X_POS,
+        },
+        '◁' => Block::FunnelXY {
+            flow_dir: Dir3::X_NEG,
+        },
+        '▽' => Block::FunnelXY {
+            flow_dir: Dir3::Y_POS,
+        },
+        '△' => Block::FunnelXY {
+            flow_dir: Dir3::Y_NEG,
+        },
+
+        '◉' => Block::WindSource,
+
+        '┻' => Block::BlipSpawn {
+            out_dir: Dir3::Y_NEG,
+            kind: BlipKind::A,
+            num_spawns: None,
+            activated: None,
+        },
+        '┳' => Block::BlipSpawn {
+            out_dir: Dir3::Y_POS,
+            kind: BlipKind::A,
+            num_spawns: None,
+            activated: None,
+        },
+        '┫' => Block::BlipSpawn {
+            out_dir: Dir3::X_NEG,
+            kind: BlipKind::A,
+            num_spawns: None,
+            activated: None,
+        },
+        '┣' => Block::BlipSpawn {
+            out_dir: Dir3::X_POS,
+            kind: BlipKind::A,
+            num_spawns: None,
+            activated: None,
+        },
+
+        '┷' => Block::BlipSpawn {
+            out_dir: Dir3::Y_NEG,
+            kind: BlipKind::A,
+            num_spawns: Some(1),
+            activated: None,
+        },
+        '┯' => Block::BlipSpawn {
+            out_dir: Dir3::Y_POS,
+            kind: BlipKind::A,
+            num_spawns: Some(1),
+            activated: None,
+        },
+        '┨' => Block::BlipSpawn {
+            out_dir: Dir3::X_NEG,
+            kind: BlipKind::A,
+            num_spawns: Some(1),
+            activated: None,
+        },
+        '┠' => Block::BlipSpawn {
+            out_dir: Dir3::X_POS,
+            kind: BlipKind::A,
+            num_spawns: Some(1),
+            activated: None,
+        },
+
+        '╂' => Block::BlipDuplicator {
+            out_dirs: (Dir3::Y_NEG, Dir3::Y_POS),
+            kind: None,
+            activated: None,
+        },
+        '┿' => Block::BlipDuplicator {
+            out_dirs: (Dir3::X_NEG, Dir3::X_POS),
+            kind: None,
+            activated: None,
+        },
+
+        '[' => Block::BlipWindSource {
+            button_dir: Dir3::X_NEG,
+            activated: false,
+        },
+        ']' => Block::BlipWindSource {
+            button_dir: Dir3::X_POS,
+            activated: false,
+        },
+        '⎵' => Block::BlipWindSource {
+            button_dir: Dir3::Y_POS,
+            activated: false,
+        },
+        '⎴' => Block::BlipWindSource {
+            button_dir: Dir3::Y_NEG,
+            activated: false,
+        },
+
+        '☐' => Block::Solid,
+
+        _ => panic!("No block for {}", c),
+    };
+
+    Some(block)
+}

--- a/src/machine/string_util.rs
+++ b/src/machine/string_util.rs
@@ -14,7 +14,7 @@ pub fn blocks_from_string(s: &str) -> Vec<(Point3, Block)> {
 }
 
 pub fn block_from_char(c: char) -> Option<Block> {
-    if c == '.' {
+    if c == '.' || c == ' ' {
         return None;
     }
 


### PR DESCRIPTION
The machines in the tests are described by string literals. We then apply randomly chosen transforms (rotation, shift, mirror) to the machine and run the tests multiple times.

Added `piece::Transform` to make this easier.